### PR TITLE
add sort q events + processing

### DIFF
--- a/abis/SecuredLine.json
+++ b/abis/SecuredLine.json
@@ -227,6 +227,37 @@
         {
           "indexed": true,
           "internalType": "uint256",
+          "name": "newIdx",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "oldIdx",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "oldId",
+          "type": "bytes32"
+        }
+      ],
+      "name": "SortedIntoQ",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "id",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
           "name": "amount",
           "type": "uint256"
         }

--- a/src/line-of-credit.ts
+++ b/src/line-of-credit.ts
@@ -24,6 +24,7 @@ import {
   MutualConsentRegistered,
   TradeSpigotRevenue,
   SetRates,
+  SortedIntoQ,
 } from "../generated/templates/SecuredLine/SecuredLine"
 
 import {
@@ -165,6 +166,30 @@ export function handleAddCredit(event: AddCredit): void {
     event.block.number
   )[0];
   creditEvent.save();
+}
+
+export function handleSortQ(event: SortedIntoQ): void {
+  // log.warning("calling handleAddCredit line {}, block {}", [event.address.toHexString(), event.block.number.toString()]);
+  const id = event.params.id.toHexString();
+  // Credit must exist and fields are filled in from mutual-consent
+  const credit = new Position(id);
+  // log.warning("addCredit existing p ID {}, lender {}, deposit {}", [id, credit.lender, credit.deposit.toString()])
+  credit.queue = event.params.newIdx.toI32();
+  credit.save();
+
+  const oldId = event.params.oldId.toHexString();
+  const swappedCredit = new Position(oldId);
+  // log.warning("addCredit existing p ID {}, lender {}, deposit {}", [id, credit.lender, credit.deposit.toString()])
+  swappedCredit.queue = event.params.oldIdx.toI32();
+  swappedCredit.save();
+  // No need to track events separately yet. 
+  // const eventId = getEventId(typeof SortQEvent, event.transaction.hash, event.logIndex);
+  // let creditEvent = new SortQEvent(eventId);
+  // creditEvent.block = event.block.number;
+  // creditEvent.line = event.address.toHexString();
+  // creditEvent.position = event.params.id.toHexString();
+  // creditEvent.timestamp = event.block.timestamp;
+  // creditEvent.save();
 }
 
 export function handleIncreaseCredit(event: IncreaseCredit): void {

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -104,6 +104,7 @@ templates:
         - UpdateLineStatusEvent
         - WithdrawProfitEvent
         - WithdrawDepositEvent
+        - SortQEvent
       abis:
         - name: SecuredLine
           file: ./abis/SecuredLine.json
@@ -151,6 +152,8 @@ templates:
           handler: handleTradeRevenue
         - event: Liquidate(indexed bytes32,indexed uint256,indexed address,address)
           handler: handleLiquidate
+        - event: SortedIntoQ(indexed bytes32,indexed uint256,indexed uint256,bytes32)
+          handler: handleSortQ
   - name: Spigot
     kind: ethereum/contract
     network: goerli


### PR DESCRIPTION
adds better tracking for lender repayment queue tracking. 

dependent on https://github.com/debtdao/Line-of-Credit/pull/191 being merged